### PR TITLE
Added template to detect exposed .git/config file

### DIFF
--- a/http/misconfiguration/exposed-git-config.yaml
+++ b/http/misconfiguration/exposed-git-config.yaml
@@ -1,0 +1,27 @@
+id: exposed-git-config
+
+info:
+  name: Exposed Git Config File
+  author: Sudharshan R
+  severity: high
+  description: Detects exposed .git/config file that may lead to source code disclosure
+  reference:
+    - https://book.hacktricks.xyz/pentesting-web/git-repositories
+  tags: git,source-disclosure,misconfig
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/.git/config"
+
+    matchers:
+      - type: word
+        words:
+          - "[core]"
+          - "repositoryformatversion"
+        condition: and
+
+    extractors:
+      - type: regex
+        regex:
+          - 'url = (.+)'


### PR DESCRIPTION
Template / PR Information
This template detects exposed .git/config files on web servers. When accessible, this file can leak critical repository information such as remote origin URLs, which could lead to source code disclosure, reconnaissance, and even exploitation via malicious Git submodules.

This helps identify misconfigured web servers leaking .git/config, a common oversight in deployments and often missed in standard scans.

Fixed CVE-2024-32002 / Related to CVE-2023-29007 / CVE-2025-32958

References:

https://digital.nhs.uk/cyber-alerts/2024/cc-4496

https://blog.ethiack.com/blog/git-arbitrary-configuration-injection-cve-2023-29007

https://nvd.nist.gov/vuln/detail/CVE-2025-32958

Template Validation
I've validated this template locally?
 YES